### PR TITLE
Update Environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,4 @@ dependencies:
   - aiohttp
   - pip:
       - sphinx-pythia-theme
-      - git+https://git@github.com/jnmorley/intake-markdown.git
+      - intake-markdown


### PR DESCRIPTION
intake-markdown is on PyPi now. This PR updates the environment to use the verision of intake-markdown on PyPi.